### PR TITLE
feat(events): medium priority fixes — form cleanup, end date, CTA, Event Saya tab

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { format } from 'date-fns'
-import { ArrowLeft, FilePenLine, FileText, FolderOpen, LayoutGrid, User } from 'lucide-react'
+import { ArrowLeft, Calendar, FilePenLine, FileText, FolderOpen, LayoutGrid, User } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { BlogTab } from '@/components/profile/blog-tab'
 import { EmptyState } from '@/components/profile/empty-state'
+import { EventTab } from '@/components/profile/event-tab'
 // New Components
 import { ProfileHeader } from '@/components/profile/profile-header'
 import { ProfileStats } from '@/components/profile/profile-stats'
@@ -21,6 +22,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { updateUserProfile } from '@/lib/actions/user'
 import { createClient } from '@/lib/supabase/client'
 import type { User as AuthUser } from '@/types/homepage'
+import type { AIEvent } from '@/types/events'
 
 interface ProfileUser {
   id: string
@@ -311,9 +313,11 @@ export default function ProfilePage() {
   const [user, setUser] = useState<ProfileUser | null>(null)
   const [userProjects, setUserProjects] = useState<UserProject[]>([])
   const [userPosts, setUserPosts] = useState<UserBlogPost[]>([])
+  const [userEvents, setUserEvents] = useState<AIEvent[]>([])
   const [userStats, setUserStats] = useState({
     projects: 0,
     posts: 0,
+    events: 0,
     likes: 0,
     views: 0,
   })
@@ -366,18 +370,47 @@ export default function ProfilePage() {
 
         const projectsPromise = fetchUserProjects(username)
         const postsPromise = fetchUserBlogPosts(profileUser.id)
+        const eventsPromise = isOwnerCheck
+          ? supabase
+              .from('events')
+              .select('*')
+              .eq('submitted_by', profileUser.id)
+              .order('created_at', { ascending: false })
+          : Promise.resolve({ data: [], error: null })
 
         setIsLoggedIn(!!session?.user)
         if (authUser) setCurrentUser(authUser)
         setIsOwner(isOwnerCheck)
         setUser(profileUser)
 
-        const [projects, posts] = await Promise.all([projectsPromise, postsPromise])
+        const [projects, posts, eventsResult] = await Promise.all([projectsPromise, postsPromise, eventsPromise])
         console.log('[v0] Loaded projects count:', projects.length)
         console.log('[v0] Loaded blog posts count:', posts.length)
         setUserProjects(projects)
         setUserPosts(posts)
-        setUserStats({ ...stats, posts: posts.length })
+
+        const eventsData = eventsResult.data || []
+        setUserEvents(
+          eventsData.map((e: any) => ({
+            id: e.id,
+            slug: e.slug,
+            name: e.name,
+            date: e.date,
+            time: e.time,
+            endDate: e.end_date,
+            endTime: e.end_time,
+            locationType: e.location_type,
+            locationDetail: e.location_detail,
+            description: e.description,
+            organizer: e.organizer,
+            registrationUrl: e.registration_url,
+            coverImage: e.cover_image,
+            category: e.category,
+            status: e.status,
+            approved: e.approved,
+          })),
+        )
+        setUserStats({ ...stats, posts: posts.length, events: eventsData.length })
       } catch (error) {
         console.error('[v0] Error loading profile data:', error)
       } finally {
@@ -543,6 +576,18 @@ export default function ProfilePage() {
                 Blog Posts
                 <span className="ml-1 rounded-full bg-muted-foreground/20 px-2 py-0.5 text-xs">{userStats.posts}</span>
               </TabsTrigger>
+              {isOwner && (
+                <TabsTrigger
+                  value="events"
+                  className="px-4 py-2 gap-2 data-[state=active]:bg-background"
+                >
+                  <Calendar className="h-4 w-4" />
+                  Events
+                  <span className="ml-1 rounded-full bg-muted-foreground/20 px-2 py-0.5 text-xs">
+                    {userStats.events}
+                  </span>
+                </TabsTrigger>
+              )}
               <TabsTrigger
                 value="about"
                 className="px-4 py-2 gap-2 data-[state=active]:bg-background"
@@ -592,6 +637,24 @@ export default function ProfilePage() {
                 }
                 actionLabel="Write First Post"
                 actionLink="/blog/editor"
+                isOwner={isOwner}
+              />
+            )}
+          </TabsContent>
+
+          <TabsContent
+            value="events"
+            className="mt-0 focus-visible:outline-none"
+          >
+            {userEvents.length > 0 ? (
+              <EventTab events={userEvents} />
+            ) : (
+              <EmptyState
+                icon={Calendar}
+                title="Belum Ada Event"
+                description="Kamu belum submit event apa pun. Yuk, bagikan event AI yang kamu tahu!"
+                actionLabel="Submit Event"
+                actionLink="/event/list"
                 isOwner={isOwner}
               />
             )}

--- a/app/event/list/event-list-client.tsx
+++ b/app/event/list/event-list-client.tsx
@@ -67,10 +67,11 @@ export default function EventListClient({ initialEvents }: EventListClientProps)
     persistViewMode(mode)
   }
 
-  // Apply filters and sort to mock data
+  // Apply filters and sort to server-fetched data
   const filteredEvents = applyFilters(initialEvents, {
     category: selectedCategory,
     locationType: selectedLocation,
+    sort: selectedSort,
   })
 
   return (

--- a/components/event/event-card.tsx
+++ b/components/event/event-card.tsx
@@ -271,18 +271,31 @@ export function EventCard({ event, variant = 'grid' }: EventCardProps) {
         </p>
 
         {/* CTA */}
-        <Link
-          href={`/event/${event.slug}`}
-          className={cn(
-            'mt-2 flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 font-medium text-sm',
-            'bg-primary text-primary-foreground transition-all',
-            'hover:bg-primary/90 hover:shadow-md',
-            'dark:hover:shadow-primary/20',
-          )}
-        >
-          Register Now
-          <ExternalLink className="size-4" />
-        </Link>
+        <div className="mt-2 space-y-2">
+          <a
+            href={event.registrationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              'flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 font-medium text-sm',
+              'bg-primary text-primary-foreground transition-all',
+              'hover:bg-primary/90 hover:shadow-md',
+              'dark:hover:shadow-primary/20',
+            )}
+          >
+            Register Now
+            <ExternalLink className="size-4" />
+          </a>
+          <Link
+            href={`/event/${event.slug}`}
+            className={cn(
+              'flex w-full items-center justify-center gap-1 rounded-lg px-4 py-2 text-xs font-medium',
+              'text-muted-foreground transition-colors hover:text-foreground',
+            )}
+          >
+            Detail Event
+          </Link>
+        </div>
       </div>
     </Card>
   )

--- a/components/event/submit-event-modal.tsx
+++ b/components/event/submit-event-modal.tsx
@@ -12,7 +12,6 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { useEventForm } from '@/hooks/useEventForm'
-import { submitEvent } from '@/lib/actions/events'
 import type { EventFormData } from '@/types/events'
 
 interface SubmitEventModalProps {
@@ -23,41 +22,26 @@ interface SubmitEventModalProps {
 
 export function SubmitEventModal({ open, onOpenChange, userId }: SubmitEventModalProps) {
   const router = useRouter()
-  const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const { formData, errors, setField, validateForm, resetForm } = useEventForm({
+  const { formData, errors, setField, validateForm, resetForm, handleSubmit, isLoading } = useEventForm({
     userId,
+    onSuccess: () => {
+      toast.success('Event berhasil disubmit! 🎉 Menunggu persetujuan admin.')
+      onOpenChange(false)
+      resetForm()
+      router.push('/event/list')
+    },
   })
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (!validateForm()) {
-      return
-    }
+    const result = await handleSubmit()
 
-    setIsSubmitting(true)
-
-    try {
-      const result = await submitEvent(formData as EventFormData)
-
-      if (result.success) {
-        toast.success('Event berhasil disubmit! 🎉 Menunggu persetujuan admin.')
-        onOpenChange(false)
-        resetForm()
-        router.push('/event/list')
-      } else {
-        toast.error(result.error || 'Gagal submit event. Silakan coba lagi.')
-      }
-    } catch (error) {
-      console.error('Submit event error:', error)
-      toast.error('Terjadi kesalahan saat submit event. Silakan coba lagi.')
-    } finally {
-      setIsSubmitting(false)
+    if (!result.success && result.error) {
+      toast.error(result.error || 'Gagal submit event. Silakan coba lagi.')
     }
   }
-
-  const isLoading = isSubmitting
 
   return (
     <Dialog
@@ -102,7 +86,7 @@ export function SubmitEventModal({ open, onOpenChange, userId }: SubmitEventModa
                 htmlFor="date"
                 className="form-label-enhanced"
               >
-                Tanggal *
+                Tanggal Mulai *
               </Label>
               <Input
                 id="date"
@@ -120,7 +104,7 @@ export function SubmitEventModal({ open, onOpenChange, userId }: SubmitEventModa
                 htmlFor="time"
                 className="form-label-enhanced"
               >
-                Waktu *
+                Waktu Mulai *
               </Label>
               <Input
                 id="time"
@@ -131,6 +115,43 @@ export function SubmitEventModal({ open, onOpenChange, userId }: SubmitEventModa
                 className="form-input-enhanced"
               />
               {errors.time && <p className="text-red-500 text-sm">{errors.time}</p>}
+            </div>
+          </div>
+
+          {/* End Date and Time (Optional) */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label
+                htmlFor="endDate"
+                className="form-label-enhanced"
+              >
+                Tanggal Selesai <span className="text-muted-foreground font-normal">(Opsional)</span>
+              </Label>
+              <Input
+                id="endDate"
+                type="date"
+                value={formData.endDate || ''}
+                onChange={(e) => setField('endDate', e.target.value)}
+                disabled={isLoading}
+                className="form-input-enhanced"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label
+                htmlFor="endTime"
+                className="form-label-enhanced"
+              >
+                Waktu Selesai <span className="text-muted-foreground font-normal">(Opsional)</span>
+              </Label>
+              <Input
+                id="endTime"
+                type="time"
+                value={formData.endTime || ''}
+                onChange={(e) => setField('endTime', e.target.value)}
+                disabled={isLoading}
+                className="form-input-enhanced"
+              />
             </div>
           </div>
 

--- a/components/profile/event-tab.tsx
+++ b/components/profile/event-tab.tsx
@@ -1,0 +1,112 @@
+import { Calendar, Clock, MapPin, Users } from 'lucide-react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import type { AIEvent } from '@/types/events'
+
+interface EventTabProps {
+  events: AIEvent[]
+}
+
+const statusColors: Record<string, string> = {
+  upcoming: 'bg-blue-500/10 text-blue-600 border-blue-200',
+  ongoing: 'bg-green-500/10 text-green-600 border-green-200',
+  past: 'bg-gray-500/10 text-gray-600 border-gray-200',
+}
+
+const approvalColors: Record<string, string> = {
+  true: 'bg-green-500/10 text-green-600 border-green-200',
+  false: 'bg-amber-500/10 text-amber-600 border-amber-200',
+}
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString)
+  return date.toLocaleDateString('id-ID', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+export function EventTab({ events }: EventTabProps) {
+  return (
+    <div className="grid gap-4">
+      {events.map((event) => (
+        <Card
+          key={event.id}
+          className={cn(
+            'group overflow-hidden border-border/50 bg-card/50 backdrop-blur-sm',
+            'transition-all duration-300 hover:border-border hover:bg-card hover:shadow-lg',
+          )}
+        >
+          <div className="flex flex-col sm:flex-row">
+            {/* Cover Image */}
+            <div className="relative h-40 w-full shrink-0 overflow-hidden sm:h-auto sm:w-48">
+              <Image
+                src={event.coverImage}
+                alt={event.name}
+                fill
+                sizes="192px"
+                loading="lazy"
+                className="object-cover transition-transform duration-500 group-hover:scale-105"
+                onError={(e) => {
+                  e.currentTarget.src = '/placeholder.jpg'
+                }}
+              />
+            </div>
+
+            {/* Content */}
+            <div className="flex flex-1 flex-col justify-between p-4">
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge
+                    variant="outline"
+                    className={cn('text-xs', statusColors[event.status] || statusColors.upcoming)}
+                  >
+                    {event.status}
+                  </Badge>
+                  <Badge
+                    variant="outline"
+                    className={cn('text-xs', approvalColors[String(event.approved)] || approvalColors.false)}
+                  >
+                    {event.approved ? 'Disetujui' : 'Menunggu Review'}
+                  </Badge>
+                </div>
+
+                <h3 className="font-semibold text-foreground text-base leading-snug tracking-tight">
+                  <Link
+                    href={`/event/${event.slug}`}
+                    className="hover:text-primary transition-colors"
+                  >
+                    {event.name}
+                  </Link>
+                </h3>
+
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-muted-foreground text-sm">
+                  <div className="flex items-center gap-1.5">
+                    <Calendar className="size-3.5 opacity-60" />
+                    <span>{formatDate(event.date)}</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <Clock className="size-3.5 opacity-60" />
+                    <span>{event.time}</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <MapPin className="size-3.5 opacity-60" />
+                    <span className="line-clamp-1">{event.locationDetail}</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <Users className="size-3.5 opacity-60" />
+                    <span>{event.organizer}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/docs/events-feature/next-steps.md
+++ b/docs/events-feature/next-steps.md
@@ -1,0 +1,41 @@
+# Events feature — next steps
+
+Prioritas: **High**, **Medium**, **Low**. Ringkasan dari review fitur AI Events (listing, detail, submit, approval admin).
+
+---
+
+## High
+
+1. **Kunci halaman detail ke konten yang sudah disetujui** — Tambahkan filter `approved = true` pada `getEventBySlug` (dan pertimbangkan juga untuk related events / metadata OG), supaya event pending tidak bisa diakses lewat URL langsung.
+
+2. **Sambungkan kontrol “Urutkan” (Terdekat / Terbaru) ke data** — Saat ini `selectedSort` tidak memengaruhi hasil; samakan perilaku dengan `getEvents` (mis. `latest` = `created_at` desc) atau tambahkan helper sort di client yang konsisten dengan server.
+
+3. **Tangani tabrakan `slug` dan error Supabase yang jelas** — Insert bisa gagal jika slug duplikat; tangkap error unik, beri pesan UI (“nama sudah dipakai, ubah nama”), atau gunakan strategi slug unik (suffix).
+
+4. **`status` event selaras dengan waktu** — Job ringan/cron atau computed saat read: set `past` / `upcoming` berdasarkan tanggal agar badge dan CTA konsisten tanpa edit manual.
+
+---
+
+## Medium
+
+5. **Rapikan `useEventForm`** — Hapus atau ganti “Phase 1 mock” di `handleSubmit` agar tidak menyesatkan maintainer; satu jalur submit lewat server action saja, atau panggil `submitEvent` dari hook dengan kontrak yang jelas.
+
+6. **UX kartu & CTA** — Pisahkan “Detail” vs “Daftar”; atau di grid arahkan tombol utama ke `registrationUrl` (dengan `rel`/security) dan sediakan link sekunder ke detail — kurangi klik yang tidak perlu jika niatnya registrasi.
+
+7. **Form lengkap vs skema DB** — Kolom `end_date` / `end_time` ada di DB dan detail sudah memakai `formatEventDateRange`, tapi form submit belum; tambahkan field opsional untuk event multi-hari.
+
+8. **Notifikasi & transparansi untuk submitter** — Email atau in-app (mis. “sedang ditinjau” / “disetujui”) dan halaman “event saya” read-only supaya pengguna tidak harus menebak setelah submit.
+
+---
+
+## Low
+
+9. **Uji otomatis & konsistensi RLS** — Playwright untuk alur list → detail → submit → approve; plus tes bahwa policy Supabase selaras dengan asumsi app (anon tidak baca pending, dll.).
+
+10. **`lib/events-utils` mock vs nyata** — Deprecate atau hapus `getEventBySlug` / `getRelatedEvents` dari mock jika tidak dipakai; dokumentasikan satu sumber kebenaran (Supabase) untuk menghindari regressi dokumentasi (mis. file `.kiro` yang masih mengacu mock).
+
+---
+
+## Urutan kerja yang disarankan
+
+Mulai dari **(1) + (2) + (3)** untuk dampak besar dengan risiko relatif terkendali.

--- a/hooks/useEventForm.ts
+++ b/hooks/useEventForm.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { generateEventSlug, validateEventForm } from '@/lib/event-form-utils'
+import { submitEvent } from '@/lib/actions/events'
 import type { EventFormData } from '@/types/events'
 
 export interface UseEventFormReturn {
@@ -80,7 +81,6 @@ export function useEventForm({ userId, onSuccess }: UseEventFormProps): UseEvent
   }
 
   const handleSubmit = async (): Promise<SubmitResult> => {
-    // Validate form
     if (!validateForm()) {
       return {
         success: false,
@@ -91,19 +91,14 @@ export function useEventForm({ userId, onSuccess }: UseEventFormProps): UseEvent
     setIsLoading(true)
 
     try {
-      // Phase 1: Mock submission (console.log)
-      console.log('[useEventForm] Submitting event:', formData)
-
-      // Simulate API delay
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-
-      // Phase 1: Always succeed
+      const result = await submitEvent(formData as EventFormData)
       setIsLoading(false)
-      onSuccess?.()
 
-      return {
-        success: true,
+      if (result.success) {
+        onSuccess?.()
       }
+
+      return result
     } catch (error) {
       setIsLoading(false)
       console.error('[useEventForm] Submission error:', error)

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -5,7 +5,18 @@ import { ROLES } from '@/lib/actions/admin/schemas'
 import { validateEventForm } from '@/lib/event-form-utils'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
-import type { AIEvent, EventCategory, EventFormData, EventLocationType } from '@/types/events'
+import type { AIEvent, EventCategory, EventFormData, EventLocationType, EventStatus } from '@/types/events'
+
+function computeEventStatus(date: string): EventStatus {
+  const eventDate = new Date(date)
+  eventDate.setHours(0, 0, 0, 0)
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  if (eventDate < today) return 'past'
+  if (eventDate.getTime() === today.getTime()) return 'ongoing'
+  return 'upcoming'
+}
 
 // Helper to map DB result (snake_case) to AIEvent (camelCase)
 function mapEventFromDB(data: any): AIEvent {
@@ -24,7 +35,8 @@ function mapEventFromDB(data: any): AIEvent {
     registrationUrl: data.registration_url,
     coverImage: data.cover_image,
     category: data.category as EventCategory,
-    status: data.status,
+    status: computeEventStatus(data.date),
+    createdAt: data.created_at,
   }
 }
 
@@ -100,7 +112,12 @@ export async function getEventBySlug(slug: string) {
 
   const supabase = await createClient()
 
-  const { data, error } = await supabase.from('events').select('*').eq('slug', sanitizedSlug).single()
+  const { data, error } = await supabase
+    .from('events')
+    .select('*')
+    .eq('slug', sanitizedSlug)
+    .eq('approved', true)
+    .single()
 
   if (error) {
     console.error('Error fetching event by slug:', error)
@@ -168,10 +185,28 @@ export async function submitEvent(formData: EventFormData) {
       submitted_by: user.id, // Use authenticated user ID
     }
 
-    const { error } = await supabase.from('events').insert(dbData)
+    // Insert with unique slug handling (auto-suffix on collision)
+    let currentSlug = dbData.slug
+    let insertError: any = null
+    const maxRetries = 5
 
-    if (error) {
-      console.error('Error submitting event:', error)
+    for (let i = 0; i < maxRetries; i++) {
+      const { error } = await supabase.from('events').insert({ ...dbData, slug: currentSlug })
+      if (!error) {
+        insertError = null
+        break
+      }
+      insertError = error
+      // 23505 = unique violation (assume slug collision)
+      if (error.code === '23505') {
+        currentSlug = `${dbData.slug}-${i + 2}`
+        continue
+      }
+      break
+    }
+
+    if (insertError) {
+      console.error('Error submitting event:', insertError)
       return { success: false, error: 'Failed to submit event' }
     }
 

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -172,7 +172,8 @@ export async function submitEvent(formData: EventFormData) {
       name: formData.name,
       date: formData.date,
       time: formData.time,
-      // end_date and end_time are omitted from EventFormData
+      end_date: formData.endDate || null,
+      end_time: formData.endTime || null,
       location_type: formData.locationType,
       location_detail: formData.locationDetail,
       description: formData.description,
@@ -323,5 +324,35 @@ export async function rejectEvent(eventId: string) {
   } catch (error) {
     console.error('Unexpected error rejecting event:', error)
     return { success: false, error: 'An unexpected error occurred' }
+  }
+}
+
+// Get events submitted by the current user
+export async function getMyEvents() {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return { events: [], error: 'Unauthorized' }
+    }
+
+    const { data, error } = await supabase
+      .from('events')
+      .select('*')
+      .eq('submitted_by', user.id)
+      .order('created_at', { ascending: false })
+
+    if (error) {
+      console.error('Error fetching my events:', error)
+      return { events: [], error: 'Failed to fetch events' }
+    }
+
+    return { events: data?.map(mapEventFromDB) || [] }
+  } catch (error) {
+    console.error('Unexpected error fetching my events:', error)
+    return { events: [], error: 'An unexpected error occurred' }
   }
 }

--- a/lib/events-utils.ts
+++ b/lib/events-utils.ts
@@ -132,6 +132,7 @@ export interface EventFilters {
   locationType?: EventLocationType | 'All'
   startDate?: string
   endDate?: string
+  sort?: 'nearest' | 'latest'
 }
 
 export function applyFilters(events: AIEvent[], filters: EventFilters): AIEvent[] {
@@ -147,6 +148,14 @@ export function applyFilters(events: AIEvent[], filters: EventFilters): AIEvent[
 
   if (filters.startDate || filters.endDate) {
     filtered = filterByDateRange(filtered, filters.startDate, filters.endDate)
+  }
+
+  if (filters.sort === 'latest') {
+    return [...filtered].sort((a, b) => {
+      const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0
+      const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0
+      return dateB - dateA
+    })
   }
 
   return sortByNearestDate(filtered)

--- a/lib/server/events-public.ts
+++ b/lib/server/events-public.ts
@@ -1,7 +1,18 @@
 import { createClient } from '@supabase/supabase-js'
 import { unstable_cache } from 'next/cache'
 import { getSupabaseConfig } from '@/lib/env-config'
-import type { AIEvent, EventCategory, EventLocationType } from '@/types/events'
+import type { AIEvent, EventCategory, EventLocationType, EventStatus } from '@/types/events'
+
+function computeEventStatus(date: string): EventStatus {
+  const eventDate = new Date(date)
+  eventDate.setHours(0, 0, 0, 0)
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  if (eventDate < today) return 'past'
+  if (eventDate.getTime() === today.getTime()) return 'ongoing'
+  return 'upcoming'
+}
 
 interface EventRow {
   id: string
@@ -18,7 +29,7 @@ interface EventRow {
   registration_url: string
   cover_image: string
   category: EventCategory
-  status: AIEvent['status']
+  created_at: string | null
 }
 
 function mapEventFromDB(data: EventRow): AIEvent {
@@ -37,7 +48,8 @@ function mapEventFromDB(data: EventRow): AIEvent {
     registrationUrl: data.registration_url,
     coverImage: data.cover_image,
     category: data.category,
-    status: data.status,
+    status: computeEventStatus(data.date),
+    createdAt: data.created_at ?? undefined,
   }
 }
 

--- a/types/events.ts
+++ b/types/events.ts
@@ -18,6 +18,7 @@ export interface AIEvent {
   coverImage: string
   category: EventCategory
   status: EventStatus
+  createdAt?: string
 }
 
 export interface EventFormData extends Omit<AIEvent, 'id' | 'endDate' | 'endTime'> {

--- a/types/events.ts
+++ b/types/events.ts
@@ -19,9 +19,10 @@ export interface AIEvent {
   category: EventCategory
   status: EventStatus
   createdAt?: string
+  approved?: boolean
 }
 
-export interface EventFormData extends Omit<AIEvent, 'id' | 'endDate' | 'endTime'> {
+export interface EventFormData extends Omit<AIEvent, 'id'> {
   approved: boolean
   submitted_by: string
 }


### PR DESCRIPTION
## Changes

### 🧹 useEventForm cleanup (#5)
- Removed dead "Phase 1 mock" code from `handleSubmit`.
- Hook now imports and calls `submitEvent` server action directly.
- `SubmitEventModal` delegates submission to `useEventForm.handleSubmit()` via `onSuccess` callback.

### 📅 Optional end date / end time (#7)
- `EventFormData` type restored `endDate` and `endTime` fields.
- Submit form now shows optional "Tanggal Selesai" and "Waktu Selesai" inputs.
- `submitEvent` server action maps `endDate` / `endTime` to DB `end_date` / `end_time`.

### 🎯 Event card CTA (#6)
- Grid variant primary button now links directly to `registrationUrl` (`target=_blank`, `rel=noopener noreferrer`).
- Secondary "Detail Event" link added below for users who want to read more first.

### 👤 Event Saya tab on profile (#8)
- New `getMyEvents` server action fetches events by `submitted_by`.
- New `EventTab` component displays submitted events with status + approval badges.
- Tab only visible to profile owner (`isOwner`) on `/[username]` page.
- Empty state prompts owner to submit their first event.

---

Closes medium-priority items 5–8 from `docs/events-feature/next-steps.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event submission and retrieval paths (server actions + Supabase queries), including slug-collision handling and approval gating, which could affect what users can see/submit if incorrect. UI changes are straightforward but depend on new/updated event fields (`createdAt`, `approved`, end date/time).
> 
> **Overview**
> Adds an owner-only **“Events”** tab on user profiles that lists the user’s submitted events (with approval/status badges) and an empty-state CTA to submit new ones.
> 
> Cleans up the event submit flow by moving submission into `useEventForm.handleSubmit()` (calling the `submitEvent` server action), and extends the submit modal + types to support optional `endDate`/`endTime` persisted to `end_date`/`end_time`.
> 
> Improves event listing/detail behavior: event cards now primary-link to `registrationUrl` (new tab) with a secondary “Detail Event” link, client-side filters now honor `selectedSort` via `applyFilters` (`latest` uses `createdAt`), `getEventBySlug` is restricted to `approved = true`, event `status` is computed from date on read, and `submitEvent` retries with slug suffixes on unique-collision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14341daa6cf201359a4b1c78d7bac3017755d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->