### PR TITLE
Fix event status date parsing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,12 @@ Dated implementation and design plans.
 
 - [Landing Page UI Guidelines Fix Plan](./plans/2026-04-02-landing-page-ui-guidelines-fixes.md) - Homepage accessibility, motion, and URL-state fix plan
 
+### Events
+
+Feature follow-up notes for the AI Events experience.
+
+- [Events Feature Next Steps](./events-feature/next-steps.md) - Prioritized follow-up work for event listing, detail, submit, and approval flows
+
 ### Testing
 
 Testing guides dan checklists.

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -3,20 +3,10 @@
 import { revalidatePath, revalidateTag } from 'next/cache'
 import { ROLES } from '@/lib/actions/admin/schemas'
 import { validateEventForm } from '@/lib/event-form-utils'
+import { computeEventStatus } from '@/lib/event-status'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
-import type { AIEvent, EventCategory, EventFormData, EventLocationType, EventStatus } from '@/types/events'
-
-function computeEventStatus(date: string): EventStatus {
-  const eventDate = new Date(date)
-  eventDate.setHours(0, 0, 0, 0)
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-
-  if (eventDate < today) return 'past'
-  if (eventDate.getTime() === today.getTime()) return 'ongoing'
-  return 'upcoming'
-}
+import type { AIEvent, EventCategory, EventFormData, EventLocationType } from '@/types/events'
 
 // Helper to map DB result (snake_case) to AIEvent (camelCase)
 function mapEventFromDB(data: any): AIEvent {

--- a/lib/event-status.ts
+++ b/lib/event-status.ts
@@ -1,0 +1,36 @@
+import type { EventStatus } from '@/types/events'
+
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/
+
+export function parseDateOnlyAsLocalDate(date: string): Date {
+  const match = DATE_ONLY_PATTERN.exec(date)
+
+  if (!match) {
+    throw new Error('Event date must use YYYY-MM-DD format')
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const localDate = new Date(year, month - 1, day)
+  localDate.setHours(0, 0, 0, 0)
+
+  if (localDate.getFullYear() !== year || localDate.getMonth() !== month - 1 || localDate.getDate() !== day) {
+    throw new Error('Event date must be a valid calendar date')
+  }
+
+  return localDate
+}
+
+export function computeEventStatus(date: string, today: Date = new Date()): EventStatus {
+  if (!(today instanceof Date) || Number.isNaN(today.getTime())) {
+    throw new Error('Today must be a valid Date')
+  }
+
+  const eventDate = parseDateOnlyAsLocalDate(date)
+  const currentDate = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+
+  if (eventDate < currentDate) return 'past'
+  if (eventDate.getTime() === currentDate.getTime()) return 'ongoing'
+  return 'upcoming'
+}

--- a/lib/server/events-public.ts
+++ b/lib/server/events-public.ts
@@ -1,18 +1,8 @@
 import { createClient } from '@supabase/supabase-js'
 import { unstable_cache } from 'next/cache'
 import { getSupabaseConfig } from '@/lib/env-config'
-import type { AIEvent, EventCategory, EventLocationType, EventStatus } from '@/types/events'
-
-function computeEventStatus(date: string): EventStatus {
-  const eventDate = new Date(date)
-  eventDate.setHours(0, 0, 0, 0)
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-
-  if (eventDate < today) return 'past'
-  if (eventDate.getTime() === today.getTime()) return 'ongoing'
-  return 'upcoming'
-}
+import { computeEventStatus } from '@/lib/event-status'
+import type { AIEvent, EventCategory, EventLocationType } from '@/types/events'
 
 interface EventRow {
   id: string

--- a/tests/unit/lib/event-status.spec.ts
+++ b/tests/unit/lib/event-status.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { computeEventStatus, parseDateOnlyAsLocalDate } from '@/lib/event-status'
+
+function withTimezone(timezone: string, callback: () => void) {
+  const originalTimezone = process.env.TZ
+
+  try {
+    process.env.TZ = timezone
+    callback()
+  } finally {
+    if (originalTimezone === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = originalTimezone
+    }
+  }
+}
+
+describe('event status helpers', () => {
+  it('parses date-only strings as local calendar dates', () => {
+    withTimezone('America/Los_Angeles', () => {
+      const parsed = parseDateOnlyAsLocalDate('2026-05-03')
+
+      expect(parsed.getFullYear()).toBe(2026)
+      expect(parsed.getMonth()).toBe(4)
+      expect(parsed.getDate()).toBe(3)
+      expect(parsed.getHours()).toBe(0)
+    })
+  })
+
+  it('computes status by local calendar day', () => {
+    const today = new Date(2026, 4, 3, 15, 30)
+
+    expect(computeEventStatus('2026-05-02', today)).toBe('past')
+    expect(computeEventStatus('2026-05-03', today)).toBe('ongoing')
+    expect(computeEventStatus('2026-05-04', today)).toBe('upcoming')
+  })
+
+  it('rejects impossible date-only strings', () => {
+    expect(() => parseDateOnlyAsLocalDate('2026-02-30')).toThrow('valid calendar date')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add the events next-steps document to the docs index.
- Centralize event status computation with explicit local parsing for `YYYY-MM-DD` dates.
- Reuse the shared status helper in server action and public cached event readers.
- Add focused unit coverage for local date-only parsing and status classification.

## Verification
- `git diff --check`
- `bun test tests/unit/lib/event-status.spec.ts` (blocked: `bun` is not installed in this cloud image)
- `npx vitest run tests/unit/lib/event-status.spec.ts` (blocked: `node`/`npx` are not installed in this cloud image)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-326fe41e-a063-4823-8241-7903b5ff018a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-326fe41e-a063-4823-8241-7903b5ff018a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

