### PR TITLE
Fix project skeleton loading getting stuck

### DIFF
--- a/hooks/useProjectFilters.ts
+++ b/hooks/useProjectFilters.ts
@@ -4,7 +4,7 @@
  */
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { fetchProjectsWithSorting } from '@/lib/actions'
 import { getCategories } from '@/lib/categories'
 import type { Project, ProjectFilterOption, SortBy } from '@/types/homepage'
@@ -19,6 +19,9 @@ interface UseProjectFiltersOptions {
 
 const ALL_FILTER_VALUE = 'all'
 const DEFAULT_SORT: SortBy = 'trending'
+const PROJECT_FETCH_TIMEOUT_MS = 10_000
+
+type FetchProjectsResult = Awaited<ReturnType<typeof fetchProjectsWithSorting>>
 
 function normalizeSortParam(value: string | null | undefined): SortBy {
   return value === 'top' || value === 'newest' || value === 'trending' ? value : DEFAULT_SORT
@@ -30,6 +33,25 @@ function normalizeFilterParam(value: string | null | undefined, categories: Proj
   }
 
   return categories.some((category) => category.value === value) ? value : ALL_FILTER_VALUE
+}
+
+async function fetchProjectsWithTimeout(sortBy: SortBy, category?: string): Promise<FetchProjectsResult> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    return await Promise.race([
+      fetchProjectsWithSorting(sortBy, category, 20),
+      new Promise<FetchProjectsResult>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`Project fetch timed out after ${PROJECT_FETCH_TIMEOUT_MS}ms`))
+        }, PROJECT_FETCH_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
+  }
 }
 
 export function useProjectFilters({
@@ -49,7 +71,8 @@ export function useProjectFilters({
   const [filterOptions, setFilterOptions] = useState<ProjectFilterOption[]>(initialCategories)
   const [projects, setProjects] = useState<Project[]>(initialProjects)
   const [loading, setLoading] = useState(initialProjects.length === 0)
-  const [skipInitialFetch, setSkipInitialFetch] = useState(initialProjects.length > 0)
+  const shouldSkipInitialFetchRef = useRef(initialProjects.length > 0)
+  const latestRequestIdRef = useRef(0)
 
   // Fetch categories for filter options
   useEffect(() => {
@@ -96,30 +119,37 @@ export function useProjectFilters({
     }
   }, [pathname, router, searchParams, selectedFilter, selectedTrending])
 
-  // Fetch projects with sorting and abort deduplication
+  // Fetch projects with sorting while ignoring stale responses.
   useEffect(() => {
     if (!authReady) {
       return
     }
 
-    if (skipInitialFetch && selectedTrending === initialSort && selectedFilter === initialFilter) {
-      setSkipInitialFetch(false)
+    if (
+      shouldSkipInitialFetchRef.current &&
+      selectedTrending === initialSort &&
+      selectedFilter === initialFilter
+    ) {
+      shouldSkipInitialFetchRef.current = false
       return
     }
 
-    const controller = new AbortController()
+    const requestId = latestRequestIdRef.current + 1
+    latestRequestIdRef.current = requestId
+    let isActive = true
 
     const fetchProjects = async () => {
       try {
         setLoading(true)
 
-        const { projects: fetchedProjects, error } = await fetchProjectsWithSorting(
+        const { projects: fetchedProjects, error } = await fetchProjectsWithTimeout(
           selectedTrending,
           selectedFilter === ALL_FILTER_VALUE ? undefined : selectedFilter,
-          20,
         )
 
-        if (controller.signal.aborted) return
+        if (!isActive || latestRequestIdRef.current !== requestId) {
+          return
+        }
 
         if (error) {
           console.error('Error fetching projects:', error)
@@ -128,10 +158,13 @@ export function useProjectFilters({
 
         setProjects(fetchedProjects || [])
       } catch (error) {
-        if (controller.signal.aborted) return
+        if (!isActive || latestRequestIdRef.current !== requestId) {
+          return
+        }
+
         console.error('Error fetching projects:', error)
       } finally {
-        if (!controller.signal.aborted) {
+        if (isActive && latestRequestIdRef.current === requestId) {
           setLoading(false)
         }
       }
@@ -140,9 +173,9 @@ export function useProjectFilters({
     fetchProjects()
 
     return () => {
-      controller.abort()
+      isActive = false
     }
-  }, [authReady, initialFilter, initialSort, selectedTrending, selectedFilter, skipInitialFetch])
+  }, [authReady, initialFilter, initialSort, selectedTrending, selectedFilter])
 
   const loadMore = () => {
     setVisibleProjects((prev) => prev + 6)

--- a/hooks/useProjectFilters.ts
+++ b/hooks/useProjectFilters.ts
@@ -54,6 +54,23 @@ async function fetchProjectsWithTimeout(sortBy: SortBy, category?: string): Prom
   }
 }
 
+function isCurrentProjectRequest(isActive: boolean, currentRequestId: number, requestId: number): boolean {
+  return isActive && currentRequestId === requestId
+}
+
+async function loadFilteredProjects(sortBy: SortBy, selectedFilter: string): Promise<Project[]> {
+  const { projects, error } = await fetchProjectsWithTimeout(
+    sortBy,
+    selectedFilter === ALL_FILTER_VALUE ? undefined : selectedFilter,
+  )
+
+  if (error) {
+    throw new Error(error)
+  }
+
+  return projects || []
+}
+
 export function useProjectFilters({
   authReady,
   initialProjects = [],
@@ -125,11 +142,7 @@ export function useProjectFilters({
       return
     }
 
-    if (
-      shouldSkipInitialFetchRef.current &&
-      selectedTrending === initialSort &&
-      selectedFilter === initialFilter
-    ) {
+    if (shouldSkipInitialFetchRef.current && selectedTrending === initialSort && selectedFilter === initialFilter) {
       shouldSkipInitialFetchRef.current = false
       return
     }
@@ -142,29 +155,21 @@ export function useProjectFilters({
       try {
         setLoading(true)
 
-        const { projects: fetchedProjects, error } = await fetchProjectsWithTimeout(
-          selectedTrending,
-          selectedFilter === ALL_FILTER_VALUE ? undefined : selectedFilter,
-        )
+        const fetchedProjects = await loadFilteredProjects(selectedTrending, selectedFilter)
 
-        if (!isActive || latestRequestIdRef.current !== requestId) {
+        if (!isCurrentProjectRequest(isActive, latestRequestIdRef.current, requestId)) {
           return
         }
 
-        if (error) {
-          console.error('Error fetching projects:', error)
-          return
-        }
-
-        setProjects(fetchedProjects || [])
+        setProjects(fetchedProjects)
       } catch (error) {
-        if (!isActive || latestRequestIdRef.current !== requestId) {
+        if (!isCurrentProjectRequest(isActive, latestRequestIdRef.current, requestId)) {
           return
         }
 
         console.error('Error fetching projects:', error)
       } finally {
-        if (isActive && latestRequestIdRef.current === requestId) {
+        if (isCurrentProjectRequest(isActive, latestRequestIdRef.current, requestId)) {
           setLoading(false)
         }
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop the project filter hook from immediately refetching after hydration when server-rendered projects are already available
- ignore stale project fetch responses instead of relying on a local abort controller that never cancelled the server action call
- add a timeout guard so failed or hung project fetches fall out of the loading state instead of leaving the UI on skeletons forever
- refactor the hook fetch path to satisfy Biome complexity checks

## Testing
- `npm exec --yes @biomejs/biome check hooks/useProjectFilters.ts`
- unable to run `bun run lint` and `bunx tsc --noEmit` in this cloud environment because `bun`/`bunx` are not installed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5aecc3de-6909-4a53-8741-0100020ad2fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5aecc3de-6909-4a53-8741-0100020ad2fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced project filtering to more reliably handle concurrent data fetches, preventing stale results from overwriting recent requests.
  * Implemented a 10-second timeout mechanism for project data fetching to ensure better responsiveness and prevent indefinite loading states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/julianromli/vibedevid/pull/26)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->