### PR TITLE
feat(admin): sync dashboard tabs with URL

### DIFF
--- a/app/(admin)/dashboard/boards/blog/components/post-filters.tsx
+++ b/app/(admin)/dashboard/boards/blog/components/post-filters.tsx
@@ -6,6 +6,9 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { buildDashboardBoardClearHref, type DashboardTabValue } from '@/lib/admin/dashboard-tabs'
+
+const BOARD_TAB: DashboardTabValue = 'blog'
 
 export function PostFilters() {
   const router = useRouter()
@@ -16,6 +19,7 @@ export function PostFilters() {
 
   const applyFilters = () => {
     const params = new URLSearchParams(searchParams.toString())
+    params.set('tab', BOARD_TAB)
 
     if (search) params.set('search', search)
     else params.delete('search')
@@ -31,7 +35,7 @@ export function PostFilters() {
   const clearFilters = () => {
     setSearch('')
     setStatus('all')
-    router.push('?')
+    router.push(buildDashboardBoardClearHref(BOARD_TAB))
   }
 
   const hasFilters = search || status !== 'all'

--- a/app/(admin)/dashboard/boards/projects/components/project-filters.tsx
+++ b/app/(admin)/dashboard/boards/projects/components/project-filters.tsx
@@ -6,6 +6,9 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { buildDashboardBoardClearHref, type DashboardTabValue } from '@/lib/admin/dashboard-tabs'
+
+const BOARD_TAB: DashboardTabValue = 'projects'
 
 interface ProjectFiltersProps {
   categories: string[]
@@ -21,6 +24,7 @@ export function ProjectFilters({ categories }: ProjectFiltersProps) {
 
   const applyFilters = () => {
     const params = new URLSearchParams(searchParams.toString())
+    params.set('tab', BOARD_TAB)
 
     if (search) params.set('search', search)
     else params.delete('search')
@@ -40,7 +44,7 @@ export function ProjectFilters({ categories }: ProjectFiltersProps) {
     setSearch('')
     setStatus('all')
     setCategory('all')
-    router.push('?')
+    router.push(buildDashboardBoardClearHref(BOARD_TAB))
   }
 
   const hasFilters = search || status !== 'all' || category !== 'all'

--- a/app/(admin)/dashboard/boards/users/components/user-search.tsx
+++ b/app/(admin)/dashboard/boards/users/components/user-search.tsx
@@ -6,6 +6,9 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { buildDashboardBoardClearHref, type DashboardTabValue } from '@/lib/admin/dashboard-tabs'
+
+const BOARD_TAB: DashboardTabValue = 'users'
 
 export function UserSearch() {
   const router = useRouter()
@@ -24,6 +27,7 @@ export function UserSearch() {
 
   const applyFilters = () => {
     const params = new URLSearchParams(searchParams.toString())
+    params.set('tab', BOARD_TAB)
 
     if (search) params.set('search', search)
     else params.delete('search')
@@ -43,7 +47,7 @@ export function UserSearch() {
     setSearch('')
     setRole('all')
     setStatus('all')
-    router.push('?')
+    router.push(buildDashboardBoardClearHref(BOARD_TAB))
   }
 
   const hasFilters = search || role !== 'all' || status !== 'all'

--- a/app/(admin)/dashboard/components/dashboard-tabs.tsx
+++ b/app/(admin)/dashboard/components/dashboard-tabs.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import {
+  IconAnalyze,
+  IconCalendarEvent,
+  IconFileReport,
+  IconFolder,
+  IconMessageCircle,
+  IconNews,
+  IconNotification,
+  IconSettings2,
+  IconUsers,
+} from '@tabler/icons-react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import type { ReactNode } from 'react'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { buildDashboardTabHref, resolveDashboardTab } from '@/lib/admin/dashboard-tabs'
+
+interface DashboardTabsProps {
+  children: ReactNode
+}
+
+export function DashboardTabs({ children }: DashboardTabsProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const activeTab = resolveDashboardTab(searchParams.get('tab'))
+
+  const handleTabChange = (value: string) => {
+    router.push(buildDashboardTabHref(pathname, value), { scroll: false })
+  }
+
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={handleTabChange}
+      className="space-y-4"
+    >
+      <div className="w-full overflow-x-auto pb-2">
+        <TabsList>
+          <TabsTrigger
+            value="overview"
+            className="flex items-center gap-2"
+          >
+            <IconSettings2 size={14} />
+            Overview
+          </TabsTrigger>
+          <TabsTrigger
+            value="analytics"
+            className="flex items-center gap-2"
+          >
+            <IconAnalyze size={16} />
+            Analytics
+          </TabsTrigger>
+          <TabsTrigger
+            value="reports"
+            className="flex items-center gap-2"
+            disabled
+          >
+            <IconFileReport size={16} />
+            Reports
+          </TabsTrigger>
+          <TabsTrigger
+            value="notifications"
+            className="flex items-center gap-2"
+            disabled
+          >
+            <IconNotification size={16} />
+            Notifications
+          </TabsTrigger>
+          <TabsTrigger
+            value="events-approval"
+            className="flex items-center gap-2"
+          >
+            <IconCalendarEvent size={16} />
+            Events
+          </TabsTrigger>
+          <TabsTrigger
+            value="projects"
+            className="flex items-center gap-2"
+          >
+            <IconFolder size={16} />
+            Projects
+          </TabsTrigger>
+          <TabsTrigger
+            value="blog"
+            className="flex items-center gap-2"
+          >
+            <IconNews size={16} />
+            Blog
+          </TabsTrigger>
+          <TabsTrigger
+            value="users"
+            className="flex items-center gap-2"
+          >
+            <IconUsers size={16} />
+            Users
+          </TabsTrigger>
+          <TabsTrigger
+            value="comments"
+            className="flex items-center gap-2"
+          >
+            <IconMessageCircle size={16} />
+            Comments
+          </TabsTrigger>
+        </TabsList>
+      </div>
+      {children}
+    </Tabs>
+  )
+}
+
+export function DashboardTabsFallback() {
+  return (
+    <div className="space-y-4">
+      <div className="bg-muted h-9 w-full max-w-3xl animate-pulse rounded-lg" />
+      <div className="bg-muted h-64 w-full animate-pulse rounded-lg" />
+    </div>
+  )
+}

--- a/app/(admin)/dashboard/page.tsx
+++ b/app/(admin)/dashboard/page.tsx
@@ -1,16 +1,6 @@
-import {
-  IconAnalyze,
-  IconCalendarEvent,
-  IconFileReport,
-  IconFolder,
-  IconMessageCircle,
-  IconNews,
-  IconNotification,
-  IconSettings2,
-  IconUsers,
-} from '@tabler/icons-react'
+import { Suspense } from 'react'
 import { Header } from '@/components/admin-panel/header'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { TabsContent } from '@/components/ui/tabs'
 import Analytics from './boards/analytics'
 import BlogPage from './boards/blog/page'
 import CommentsPage from './boards/comments/page'
@@ -18,6 +8,7 @@ import EventsApproval from './boards/events-approval/page'
 import Overview from './boards/overview'
 import ProjectsPage from './boards/projects/page'
 import UsersPage from './boards/users/page'
+import { DashboardTabs, DashboardTabsFallback } from './components/dashboard-tabs'
 import Dashboard1Actions from './components/dashboard-1-actions'
 
 interface SearchParams {
@@ -30,11 +21,6 @@ interface SearchParams {
 }
 
 export default async function Dashboard1Page({ searchParams }: { searchParams: Promise<SearchParams> }) {
-  const params = await searchParams
-
-  // Determine active tab from URL or default to overview
-  const activeTab = params.tab || 'overview'
-
   return (
     <>
       <Header />
@@ -47,123 +33,52 @@ export default async function Dashboard1Page({ searchParams }: { searchParams: P
           <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
           <Dashboard1Actions />
         </div>
-        <Tabs
-          orientation="vertical"
-          defaultValue={activeTab}
-          className="space-y-4"
-        >
-          <div className="w-full overflow-x-auto pb-2">
-            <TabsList>
-              <TabsTrigger
-                value="overview"
-                className="flex items-center gap-2"
-              >
-                <IconSettings2 size={14} />
-                Overview
-              </TabsTrigger>
-              <TabsTrigger
-                value="analytics"
-                className="flex items-center gap-2"
-              >
-                <IconAnalyze size={16} />
-                Analytics
-              </TabsTrigger>
-              <TabsTrigger
-                value="reports"
-                className="flex items-center gap-2"
-                disabled
-              >
-                <IconFileReport size={16} />
-                Reports
-              </TabsTrigger>
-              <TabsTrigger
-                value="notifications"
-                className="flex items-center gap-2"
-                disabled
-              >
-                <IconNotification size={16} />
-                Notifications
-              </TabsTrigger>
-              <TabsTrigger
-                value="events-approval"
-                className="flex items-center gap-2"
-              >
-                <IconCalendarEvent size={16} />
-                Events
-              </TabsTrigger>
-              <TabsTrigger
-                value="projects"
-                className="flex items-center gap-2"
-              >
-                <IconFolder size={16} />
-                Projects
-              </TabsTrigger>
-              <TabsTrigger
-                value="blog"
-                className="flex items-center gap-2"
-              >
-                <IconNews size={16} />
-                Blog
-              </TabsTrigger>
-              <TabsTrigger
-                value="users"
-                className="flex items-center gap-2"
-              >
-                <IconUsers size={16} />
-                Users
-              </TabsTrigger>
-              <TabsTrigger
-                value="comments"
-                className="flex items-center gap-2"
-              >
-                <IconMessageCircle size={16} />
-                Comments
-              </TabsTrigger>
-            </TabsList>
-          </div>
-          <TabsContent
-            value="overview"
-            className="space-y-4"
-          >
-            <Overview />
-          </TabsContent>
-          <TabsContent
-            value="analytics"
-            className="space-y-4"
-          >
-            <Analytics />
-          </TabsContent>
-          <TabsContent
-            value="events-approval"
-            className="space-y-4"
-          >
-            <EventsApproval />
-          </TabsContent>
-          <TabsContent
-            value="projects"
-            className="space-y-4"
-          >
-            <ProjectsPage searchParams={searchParams} />
-          </TabsContent>
-          <TabsContent
-            value="blog"
-            className="space-y-4"
-          >
-            <BlogPage searchParams={searchParams} />
-          </TabsContent>
-          <TabsContent
-            value="users"
-            className="space-y-4"
-          >
-            <UsersPage searchParams={searchParams} />
-          </TabsContent>
-          <TabsContent
-            value="comments"
-            className="space-y-4"
-          >
-            <CommentsPage searchParams={searchParams} />
-          </TabsContent>
-        </Tabs>
+        <Suspense fallback={<DashboardTabsFallback />}>
+          <DashboardTabs>
+            <TabsContent
+              value="overview"
+              className="space-y-4"
+            >
+              <Overview />
+            </TabsContent>
+            <TabsContent
+              value="analytics"
+              className="space-y-4"
+            >
+              <Analytics />
+            </TabsContent>
+            <TabsContent
+              value="events-approval"
+              className="space-y-4"
+            >
+              <EventsApproval />
+            </TabsContent>
+            <TabsContent
+              value="projects"
+              className="space-y-4"
+            >
+              <ProjectsPage searchParams={searchParams} />
+            </TabsContent>
+            <TabsContent
+              value="blog"
+              className="space-y-4"
+            >
+              <BlogPage searchParams={searchParams} />
+            </TabsContent>
+            <TabsContent
+              value="users"
+              className="space-y-4"
+            >
+              <UsersPage searchParams={searchParams} />
+            </TabsContent>
+            <TabsContent
+              value="comments"
+              className="space-y-4"
+            >
+              <CommentsPage searchParams={searchParams} />
+            </TabsContent>
+          </DashboardTabs>
+        </Suspense>
       </div>
     </>
   )

--- a/components/admin-panel/nav-group.tsx
+++ b/components/admin-panel/nav-group.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import type { ReactNode } from 'react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import {
@@ -17,11 +17,15 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar'
 import { Badge } from '../ui/badge'
+import { DEFAULT_DASHBOARD_TAB, resolveDashboardTab } from '@/lib/admin/dashboard-tabs'
 import type { NavGroup, NavItem } from './types'
 
 export function NavGroup({ title, items }: NavGroup) {
   const { setOpenMobile } = useSidebar()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const dashboardTab = resolveDashboardTab(searchParams.get('tab'))
+
   return (
     <SidebarGroup>
       <SidebarGroupLabel>{title}</SidebarGroupLabel>
@@ -32,7 +36,7 @@ export function NavGroup({ title, items }: NavGroup) {
               <SidebarMenuItem key={item.title}>
                 <SidebarMenuButton
                   asChild
-                  isActive={checkIsActive(pathname, item, true)}
+                  isActive={checkIsActive(pathname, dashboardTab, item, true)}
                   tooltip={item.title}
                 >
                   <Link
@@ -50,7 +54,7 @@ export function NavGroup({ title, items }: NavGroup) {
           return (
             <Collapsible
               key={item.title}
-              defaultOpen={checkIsActive(pathname, item, true)}
+              defaultOpen={checkIsActive(pathname, dashboardTab, item, true)}
               className="group/collapsible"
             >
               <SidebarMenuItem>
@@ -68,7 +72,7 @@ export function NavGroup({ title, items }: NavGroup) {
                       <SidebarMenuSubItem key={subItem.title}>
                         <SidebarMenuSubButton
                           asChild
-                          isActive={checkIsActive(pathname, subItem)}
+                          isActive={checkIsActive(pathname, dashboardTab, subItem)}
                         >
                           <Link
                             href={subItem.url}
@@ -96,11 +100,31 @@ const NavBadge = ({ children }: { children: ReactNode }) => (
   <Badge className="rounded-full px-1 py-0 text-xs">{children}</Badge>
 )
 
-function checkIsActive(href: string, item: NavItem, mainNav = false) {
+function checkIsActive(pathname: string, dashboardTab: string, item: NavItem, mainNav = false) {
+  if (pathname === '/dashboard' || pathname.startsWith('/dashboard/')) {
+    const itemTab = getDashboardTabFromNavUrl(item.url)
+    if (itemTab !== null) {
+      return dashboardTab === itemTab
+    }
+  }
+
   return (
-    href === item.url || // /endpint?search=param
-    href.split('?')[0] === item.url || // endpoint
-    !!item?.items?.filter((i) => i.url === href).length || // if child nav is active
-    (mainNav && href.split('/')[1] !== '' && href.split('/')[1] === item?.url?.split('/')[1])
+    pathname === item.url.split('?')[0] ||
+    !!item?.items?.filter((i) => checkIsActive(pathname, dashboardTab, i)).length ||
+    (mainNav && pathname.split('/')[1] !== '' && pathname.split('/')[1] === item?.url?.split('/')[1])
   )
+}
+
+function getDashboardTabFromNavUrl(url: string): string | null {
+  if (!url.startsWith('/dashboard')) {
+    return null
+  }
+
+  const queryIndex = url.indexOf('?')
+  if (queryIndex === -1) {
+    return DEFAULT_DASHBOARD_TAB
+  }
+
+  const params = new URLSearchParams(url.slice(queryIndex))
+  return resolveDashboardTab(params.get('tab'))
 }

--- a/lib/admin/dashboard-tabs.ts
+++ b/lib/admin/dashboard-tabs.ts
@@ -1,0 +1,38 @@
+export const DASHBOARD_TAB_VALUES = [
+  'overview',
+  'analytics',
+  'events-approval',
+  'projects',
+  'blog',
+  'users',
+  'comments',
+] as const
+
+export type DashboardTabValue = (typeof DASHBOARD_TAB_VALUES)[number]
+
+export const DEFAULT_DASHBOARD_TAB: DashboardTabValue = 'overview'
+
+export function isDashboardTabValue(value: string | null | undefined): value is DashboardTabValue {
+  return value != null && (DASHBOARD_TAB_VALUES as readonly string[]).includes(value)
+}
+
+export function resolveDashboardTab(tab: string | null | undefined): DashboardTabValue {
+  return isDashboardTabValue(tab) ? tab : DEFAULT_DASHBOARD_TAB
+}
+
+/** Tab-only URL used when switching tabs (drops board filters/pagination). */
+export function buildDashboardTabHref(pathname: string, tab: string): string {
+  const resolved = resolveDashboardTab(tab)
+  if (resolved === DEFAULT_DASHBOARD_TAB) {
+    return pathname
+  }
+  return `${pathname}?tab=${resolved}`
+}
+
+/** Query string that keeps the current board tab after clearing filters. */
+export function buildDashboardBoardClearHref(tab: DashboardTabValue): string {
+  if (tab === DEFAULT_DASHBOARD_TAB) {
+    return '?'
+  }
+  return `?tab=${tab}`
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements admin dashboard improvement **#1**: bidirectional sync between the horizontal tab bar and the `?tab=` query parameter on `/dashboard`.

## Changes

- **`DashboardTabs` client component** — controlled Radix tabs read `tab` from the URL and call `router.push` on change (tab-only URL, clears board filters/pagination).
- **`lib/admin/dashboard-tabs.ts`** — shared tab allowlist, validation, and href helpers.
- **Board filters** (projects, blog, users) — always set `tab` when applying filters; preserve `tab` when clearing filters.
- **Sidebar `NavGroup`** — active state uses pathname + `?tab=` so sidebar highlights match the selected tab.

## Behavior

| Action | URL |
|--------|-----|
| Open Overview | `/dashboard` |
| Click Projects tab | `/dashboard?tab=projects` |
| Sidebar → Events | `/dashboard?tab=events-approval` |
| Switch to Blog tab | `/dashboard?tab=blog` (filters reset) |
| Refresh on Projects | Stays on Projects |

Invalid `?tab=` values fall back to Overview.

## Testing

- Click each tab and confirm URL updates
- Refresh page on each tab — same tab remains active
- Sidebar links and tab bar stay in sync
- Apply/clear filters on Projects/Blog/Users — `tab` preserved
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a52cc7f0-755c-4965-88a6-a8633e17f47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a52cc7f0-755c-4965-88a6-a8633e17f47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

