### PR TITLE
feat(admin): Admin management tab for role control

### DIFF
--- a/app/(admin)/dashboard/boards/admin-management/components/admin-management-board.tsx
+++ b/app/(admin)/dashboard/boards/admin-management/components/admin-management-board.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { IconSearch, IconShield, IconShieldOff, IconUserPlus } from '@tabler/icons-react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import {
+  grantAdminAccess,
+  grantModeratorAccess,
+  type PrivilegedUser,
+  revokePrivilegedAccess,
+  searchUsersForAdminGrant,
+} from '@/lib/actions/admin/admins'
+import { ROLES } from '@/lib/actions/admin/schemas'
+
+interface SearchUser {
+  id: string
+  username: string
+  display_name: string
+  email: string
+  avatar_url: string | null
+  role: number
+}
+
+interface AdminManagementBoardProps {
+  initialUsers: PrivilegedUser[]
+  adminCount: number
+  moderatorCount: number
+}
+
+export function AdminManagementBoard({ initialUsers, adminCount, moderatorCount }: AdminManagementBoardProps) {
+  const router = useRouter()
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<SearchUser[]>([])
+  const [searching, setSearching] = useState(false)
+  const [pendingUserId, setPendingUserId] = useState<string | null>(null)
+  const [confirmAction, setConfirmAction] = useState<{
+    userId: string
+    name: string
+    action: 'revoke-admin' | 'revoke-moderator'
+  } | null>(null)
+
+  const refresh = useCallback(() => {
+    router.refresh()
+  }, [router])
+
+  const handleSearch = async () => {
+    if (searchQuery.trim().length < 2) {
+      toast.error('Enter at least 2 characters to search')
+      return
+    }
+
+    setSearching(true)
+    try {
+      const result = await searchUsersForAdminGrant(searchQuery)
+      if (result.success && result.users) {
+        setSearchResults(result.users)
+        if (result.users.length === 0) {
+          toast.message('No standard users found matching your search')
+        }
+      } else {
+        toast.error(result.error || 'Search failed')
+      }
+    } catch {
+      toast.error('An error occurred while searching')
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  const runRoleAction = async (
+    userId: string,
+    action: () => Promise<{ success: boolean; error?: string }>,
+    successMessage: string,
+  ) => {
+    setPendingUserId(userId)
+    try {
+      const result = await action()
+      if (result.success) {
+        toast.success(successMessage)
+        setSearchResults((prev) => prev.filter((u) => u.id !== userId))
+        refresh()
+      } else {
+        toast.error(result.error || 'Action failed')
+      }
+    } catch {
+      toast.error('An error occurred')
+    } finally {
+      setPendingUserId(null)
+      setConfirmAction(null)
+    }
+  }
+
+  const handleRevokeConfirm = () => {
+    if (!confirmAction) return
+    runRoleAction(confirmAction.userId, () => revokePrivilegedAccess(confirmAction.userId), 'Access updated')
+  }
+
+  const getRoleBadge = (role: number) => {
+    if (role === ROLES.ADMIN) {
+      return <Badge className="bg-red-500/10 text-red-600">Admin</Badge>
+    }
+    if (role === ROLES.MODERATOR) {
+      return <Badge className="bg-blue-500/10 text-blue-600">Moderator</Badge>
+    }
+    return <Badge variant="secondary">User</Badge>
+  }
+
+  const canRevokeAdmin = (user: PrivilegedUser) => {
+    if (user.role !== ROLES.ADMIN) return true
+    if (user.is_current_user) return false
+    if (adminCount <= 1) return false
+    return true
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="flex items-center gap-2 font-semibold text-lg">
+          <IconShield className="h-5 w-5" />
+          Admin management
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          Grant or revoke admin and moderator access. Admins have full dashboard control; moderators can approve events.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Admins</CardDescription>
+            <CardTitle className="text-3xl">{adminCount}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-muted-foreground text-xs">Full platform access including this panel</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Moderators</CardDescription>
+            <CardTitle className="text-3xl">{moderatorCount}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-muted-foreground text-xs">Can moderate events; no full admin dashboard</CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Add admin or moderator</CardTitle>
+          <CardDescription>Search registered users with standard (member) role only</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <div className="relative flex-1">
+              <IconSearch className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+              <Input
+                placeholder="Search by username or display name..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                className="pl-10"
+              />
+            </div>
+            <Button
+              onClick={handleSearch}
+              disabled={searching}
+              className="shrink-0"
+            >
+              {searching ? 'Searching...' : 'Search'}
+            </Button>
+          </div>
+
+          {searchResults.length > 0 && (
+            <div className="divide-y rounded-lg border">
+              {searchResults.map((user) => (
+                <div
+                  key={user.id}
+                  className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex items-center gap-3">
+                    <Avatar className="h-10 w-10">
+                      <AvatarImage
+                        src={user.avatar_url || ''}
+                        alt={user.display_name}
+                      />
+                      <AvatarFallback>{user.display_name[0]}</AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <p className="font-medium">{user.display_name}</p>
+                      <p className="text-muted-foreground text-sm">@{user.username}</p>
+                      {user.email && <p className="text-muted-foreground text-xs">{user.email}</p>}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      disabled={pendingUserId === user.id}
+                      onClick={() =>
+                        runRoleAction(user.id, () => grantAdminAccess(user.id), `${user.display_name} is now an admin`)
+                      }
+                    >
+                      <IconUserPlus className="mr-1 h-4 w-4" />
+                      Make admin
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      disabled={pendingUserId === user.id}
+                      onClick={() =>
+                        runRoleAction(
+                          user.id,
+                          () => grantModeratorAccess(user.id),
+                          `${user.display_name} is now a moderator`,
+                        )
+                      }
+                    >
+                      Make moderator
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Current admins & moderators</CardTitle>
+          <CardDescription>
+            {initialUsers.length} privileged {initialUsers.length === 1 ? 'account' : 'accounts'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0 sm:p-0">
+          {initialUsers.length === 0 ? (
+            <p className="text-muted-foreground p-6 text-center text-sm">No admins or moderators found.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>User</TableHead>
+                    <TableHead>Role</TableHead>
+                    <TableHead>Joined</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {initialUsers.map((user) => (
+                    <TableRow key={user.id}>
+                      <TableCell>
+                        <div className="flex items-center gap-3">
+                          <Avatar className="h-9 w-9">
+                            <AvatarImage
+                              src={user.avatar_url || ''}
+                              alt={user.display_name}
+                            />
+                            <AvatarFallback>{user.display_name[0]}</AvatarFallback>
+                          </Avatar>
+                          <div>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <Link
+                                href={`/${user.username}`}
+                                className="font-medium hover:underline"
+                                target="_blank"
+                              >
+                                {user.display_name}
+                              </Link>
+                              {user.is_current_user && (
+                                <Badge
+                                  variant="outline"
+                                  className="text-xs"
+                                >
+                                  You
+                                </Badge>
+                              )}
+                            </div>
+                            <p className="text-muted-foreground text-sm">@{user.username}</p>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>{getRoleBadge(user.role)}</TableCell>
+                      <TableCell className="text-muted-foreground text-sm">
+                        {new Date(user.joined_at).toLocaleDateString('id-ID', {
+                          day: 'numeric',
+                          month: 'short',
+                          year: 'numeric',
+                        })}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex flex-wrap justify-end gap-2">
+                          {user.role === ROLES.MODERATOR && (
+                            <>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={pendingUserId === user.id}
+                                onClick={() =>
+                                  runRoleAction(
+                                    user.id,
+                                    () => grantAdminAccess(user.id),
+                                    `${user.display_name} promoted to admin`,
+                                  )
+                                }
+                              >
+                                Promote to admin
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                disabled={pendingUserId === user.id}
+                                onClick={() =>
+                                  setConfirmAction({
+                                    userId: user.id,
+                                    name: user.display_name,
+                                    action: 'revoke-moderator',
+                                  })
+                                }
+                              >
+                                Remove moderator
+                              </Button>
+                            </>
+                          )}
+                          {user.role === ROLES.ADMIN && (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="text-destructive hover:text-destructive"
+                              disabled={!canRevokeAdmin(user) || pendingUserId === user.id}
+                              onClick={() =>
+                                setConfirmAction({
+                                  userId: user.id,
+                                  name: user.display_name,
+                                  action: 'revoke-admin',
+                                })
+                              }
+                            >
+                              <IconShieldOff className="mr-1 h-4 w-4" />
+                              Remove admin
+                            </Button>
+                          )}
+                        </div>
+                        {user.role === ROLES.ADMIN && user.is_current_user && (
+                          <p className="text-muted-foreground mt-1 text-xs">Cannot remove your own access</p>
+                        )}
+                        {user.role === ROLES.ADMIN && !user.is_current_user && adminCount <= 1 && (
+                          <p className="text-muted-foreground mt-1 text-xs">At least one admin is required</p>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <AlertDialog
+        open={!!confirmAction}
+        onOpenChange={(open) => !open && setConfirmAction(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {confirmAction?.action === 'revoke-admin' ? 'Remove admin access?' : 'Remove moderator access?'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmAction?.action === 'revoke-admin'
+                ? `${confirmAction.name} will become a standard user and lose access to the admin dashboard.`
+                : `${confirmAction?.name} will become a standard user and lose moderator permissions.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRevokeConfirm}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/app/(admin)/dashboard/boards/admin-management/page.tsx
+++ b/app/(admin)/dashboard/boards/admin-management/page.tsx
@@ -1,0 +1,23 @@
+import { getPrivilegedUsers } from '@/lib/actions/admin/admins'
+import { AdminManagementBoard } from './components/admin-management-board'
+
+export default async function AdminManagementPage() {
+  const result = await getPrivilegedUsers()
+
+  if (!result.success || !result.users || !result.currentUserId) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <div className="text-destructive">Failed to load admin management</div>
+        <div className="text-muted-foreground mt-1 text-sm">{result.error || 'Unknown error'}</div>
+      </div>
+    )
+  }
+
+  return (
+    <AdminManagementBoard
+      initialUsers={result.users}
+      adminCount={result.adminCount || 0}
+      moderatorCount={result.moderatorCount || 0}
+    />
+  )
+}

--- a/app/(admin)/dashboard/components/dashboard-tabs.tsx
+++ b/app/(admin)/dashboard/components/dashboard-tabs.tsx
@@ -9,6 +9,7 @@ import {
   IconNews,
   IconNotification,
   IconSettings2,
+  IconShield,
   IconUsers,
 } from '@tabler/icons-react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -96,6 +97,13 @@ export function DashboardTabs({ children }: DashboardTabsProps) {
           >
             <IconUsers size={16} />
             Users
+          </TabsTrigger>
+          <TabsTrigger
+            value="admin-management"
+            className="flex items-center gap-2"
+          >
+            <IconShield size={16} />
+            Admins
           </TabsTrigger>
           <TabsTrigger
             value="comments"

--- a/app/(admin)/dashboard/page.tsx
+++ b/app/(admin)/dashboard/page.tsx
@@ -7,6 +7,7 @@ import CommentsPage from './boards/comments/page'
 import EventsApproval from './boards/events-approval/page'
 import Overview from './boards/overview'
 import ProjectsPage from './boards/projects/page'
+import AdminManagementPage from './boards/admin-management/page'
 import UsersPage from './boards/users/page'
 import { DashboardTabs, DashboardTabsFallback } from './components/dashboard-tabs'
 import Dashboard1Actions from './components/dashboard-1-actions'
@@ -70,6 +71,12 @@ export default async function Dashboard1Page({ searchParams }: { searchParams: P
               className="space-y-4"
             >
               <UsersPage searchParams={searchParams} />
+            </TabsContent>
+            <TabsContent
+              value="admin-management"
+              className="space-y-4"
+            >
+              <AdminManagementPage />
             </TabsContent>
             <TabsContent
               value="comments"

--- a/components/admin-panel/data/sidebar-data.tsx
+++ b/components/admin-panel/data/sidebar-data.tsx
@@ -4,6 +4,7 @@ import {
   IconLayoutDashboard,
   IconMessageCircle,
   IconNews,
+  IconShield,
   IconUsers,
 } from '@tabler/icons-react'
 import type { NavGroup } from '../types'
@@ -53,6 +54,11 @@ export const sidebarData: { navGroups: NavGroup[] } = {
           title: 'Users',
           url: '/dashboard?tab=users',
           icon: IconUsers,
+        },
+        {
+          title: 'Admin management',
+          url: '/dashboard?tab=admin-management',
+          icon: IconShield,
         },
         {
           title: 'Comments',

--- a/lib/actions/admin/admins.ts
+++ b/lib/actions/admin/admins.ts
@@ -1,0 +1,266 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { RoleSchema, ROLES, SearchSchema, UserIdSchema } from './schemas'
+
+export interface PrivilegedUser {
+  id: string
+  username: string
+  display_name: string
+  email: string
+  avatar_url: string | null
+  role: number
+  joined_at: string
+  is_current_user: boolean
+}
+
+export interface PrivilegedUsersResult {
+  success: boolean
+  users?: PrivilegedUser[]
+  adminCount?: number
+  moderatorCount?: number
+  currentUserId?: string
+  error?: string
+}
+
+export interface UserSearchResult {
+  success: boolean
+  users?: Array<{
+    id: string
+    username: string
+    display_name: string
+    email: string
+    avatar_url: string | null
+    role: number
+  }>
+  error?: string
+}
+
+async function getAdminSession() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new Error('Unauthorized')
+  }
+
+  const { data: userData } = await supabase.from('users').select('role').eq('id', user.id).single()
+
+  if (!userData || userData.role !== ROLES.ADMIN) {
+    throw new Error('Admin access required')
+  }
+
+  return { userId: user.id }
+}
+
+async function getEmailMap(userIds: string[]) {
+  const adminClient = createAdminClient()
+  const emailMap: Record<string, string> = {}
+
+  if (userIds.length === 0) return emailMap
+
+  const { data: authData, error } = await adminClient.auth.admin.listUsers({ perPage: 1000 })
+
+  if (error) {
+    console.error('List auth users error:', error)
+    return emailMap
+  }
+
+  const idSet = new Set(userIds)
+  authData.users.forEach((authUser) => {
+    if (idSet.has(authUser.id)) {
+      emailMap[authUser.id] = authUser.email || ''
+    }
+  })
+
+  return emailMap
+}
+
+function formatPrivilegedUser(
+  user: {
+    id: string
+    username: string
+    display_name: string
+    avatar_url: string | null
+    role: number | null
+    joined_at: string
+  },
+  emailMap: Record<string, string>,
+  currentUserId: string,
+): PrivilegedUser {
+  return {
+    id: user.id,
+    username: user.username,
+    display_name: user.display_name,
+    email: emailMap[user.id] || '',
+    avatar_url: user.avatar_url,
+    role: user.role ?? ROLES.USER,
+    joined_at: user.joined_at,
+    is_current_user: user.id === currentUserId,
+  }
+}
+
+export async function getPrivilegedUsers(): Promise<PrivilegedUsersResult> {
+  try {
+    const { userId } = await getAdminSession()
+    const adminClient = createAdminClient()
+
+    const { data: users, error } = await adminClient
+      .from('users')
+      .select('id, username, display_name, avatar_url, role, joined_at')
+      .in('role', [ROLES.ADMIN, ROLES.MODERATOR])
+      .order('role', { ascending: true })
+      .order('joined_at', { ascending: true })
+
+    if (error) {
+      return { success: false, error: error.message }
+    }
+
+    const emailMap = await getEmailMap(users?.map((u) => u.id) || [])
+    const formatted = (users || []).map((user) => formatPrivilegedUser(user, emailMap, userId))
+
+    return {
+      success: true,
+      users: formatted,
+      adminCount: formatted.filter((u) => u.role === ROLES.ADMIN).length,
+      moderatorCount: formatted.filter((u) => u.role === ROLES.MODERATOR).length,
+      currentUserId: userId,
+    }
+  } catch (error) {
+    console.error('Get privileged users error:', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to load admin users',
+    }
+  }
+}
+
+export async function searchUsersForAdminGrant(query: string): Promise<UserSearchResult> {
+  try {
+    await getAdminSession()
+
+    const trimmed = query.trim()
+    if (trimmed.length < 2) {
+      return { success: true, users: [] }
+    }
+
+    const sanitized = SearchSchema.parse(trimmed)
+    const adminClient = createAdminClient()
+
+    const { data: users, error } = await adminClient
+      .from('users')
+      .select('id, username, display_name, avatar_url, role')
+      .eq('role', ROLES.USER)
+      .or(`username.ilike.%${sanitized}%,display_name.ilike.%${sanitized}%`)
+      .order('joined_at', { ascending: false })
+      .limit(10)
+
+    if (error) {
+      return { success: false, error: error.message }
+    }
+
+    const emailMap = await getEmailMap(users?.map((u) => u.id) || [])
+
+    return {
+      success: true,
+      users: (users || []).map((user) => ({
+        id: user.id,
+        username: user.username,
+        display_name: user.display_name,
+        email: emailMap[user.id] || '',
+        avatar_url: user.avatar_url,
+        role: user.role ?? ROLES.USER,
+      })),
+    }
+  } catch (error) {
+    console.error('Search users for admin grant error:', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to search users',
+    }
+  }
+}
+
+async function countAdmins(adminClient: ReturnType<typeof createAdminClient>) {
+  const { count, error } = await adminClient
+    .from('users')
+    .select('*', { count: 'exact', head: true })
+    .eq('role', ROLES.ADMIN)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return count || 0
+}
+
+export async function setPrivilegedUserRole(
+  userId: string,
+  role: number,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const parsedUserId = UserIdSchema.parse(userId)
+    const parsedRole = RoleSchema.parse(role)
+    const { userId: currentUserId } = await getAdminSession()
+    const adminClient = createAdminClient()
+
+    const { data: targetUser, error: fetchError } = await adminClient
+      .from('users')
+      .select('id, role, username, display_name')
+      .eq('id', parsedUserId)
+      .single()
+
+    if (fetchError || !targetUser) {
+      return { success: false, error: 'User not found' }
+    }
+
+    const currentRole = targetUser.role ?? ROLES.USER
+    const isDemotingAdmin = currentRole === ROLES.ADMIN && parsedRole !== ROLES.ADMIN
+
+    if (isDemotingAdmin) {
+      if (parsedUserId === currentUserId) {
+        return { success: false, error: 'You cannot remove your own admin access' }
+      }
+
+      const adminCount = await countAdmins(adminClient)
+      if (adminCount <= 1) {
+        return { success: false, error: 'Cannot remove the last admin on the platform' }
+      }
+    }
+
+    const { error: updateError } = await adminClient
+      .from('users')
+      .update({ role: parsedRole, updated_at: new Date().toISOString() })
+      .eq('id', parsedUserId)
+
+    if (updateError) {
+      return { success: false, error: updateError.message }
+    }
+
+    revalidatePath('/dashboard')
+
+    return { success: true }
+  } catch (error) {
+    console.error('Set privileged user role error:', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to update role',
+    }
+  }
+}
+
+export async function grantAdminAccess(userId: string) {
+  return setPrivilegedUserRole(userId, ROLES.ADMIN)
+}
+
+export async function grantModeratorAccess(userId: string) {
+  return setPrivilegedUserRole(userId, ROLES.MODERATOR)
+}
+
+export async function revokePrivilegedAccess(userId: string) {
+  return setPrivilegedUserRole(userId, ROLES.USER)
+}

--- a/lib/admin/dashboard-tabs.ts
+++ b/lib/admin/dashboard-tabs.ts
@@ -5,6 +5,7 @@ export const DASHBOARD_TAB_VALUES = [
   'projects',
   'blog',
   'users',
+  'admin-management',
   'comments',
 ] as const
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated **Admins** tab on `/dashboard` for managing platform administrators and moderators.

## Features

- List all users with admin or moderator role
- Search standard users by username/display name and promote to **admin** or **moderator**
- Remove admin or moderator access (demote to standard user)
- Promote moderators to admin

## Safeguards

- Cannot remove your own admin access
- Cannot remove the last remaining admin
- Role updates use service-role client + zod validation

## Where to find it

- Tab: `/dashboard?tab=admin-management` (labeled **Admins**)
- Sidebar: **Admin management** under Community
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a52cc7f0-755c-4965-88a6-a8633e17f47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a52cc7f0-755c-4965-88a6-a8633e17f47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

