### PR TITLE
fix: security and production routing issues from code review

### DIFF
--- a/i18n/routing.vite.ts
+++ b/i18n/routing.vite.ts
@@ -1,7 +1,6 @@
 export const routing = {
   locales: ['id', 'en'] as const,
   defaultLocale: 'id' as const,
-  localePrefix: 'as-needed' as const,
 }
 
 export type Locale = (typeof routing.locales)[number]

--- a/lib/actions.client.ts
+++ b/lib/actions.client.ts
@@ -1,19 +1,71 @@
+import type * as actions from './actions'
 import { createRpcAction } from '@/lib/rpc-client'
 
-export const signIn = createRpcAction('actions.signIn')
-export const signUp = createRpcAction('actions.signUp')
-export const signOut = createRpcAction('actions.signOut')
-export const resetPassword = createRpcAction('actions.resetPassword')
-export const resendConfirmationEmail = createRpcAction('actions.resendConfirmationEmail')
-export const getProjectBySlug = createRpcAction('actions.getProjectBySlug')
-export const getProject = createRpcAction('actions.getProject')
-export const incrementProjectViews = createRpcAction('actions.incrementProjectViews')
-export const incrementBlogPostViews = createRpcAction('actions.incrementBlogPostViews')
-export const toggleLike = createRpcAction('actions.toggleLike')
-export const getLikeStatus = createRpcAction('actions.getLikeStatus')
-export const signInWithGoogle = createRpcAction('actions.signInWithGoogle')
-export const signInWithGitHub = createRpcAction('actions.signInWithGitHub')
-export const getBatchLikeStatus = createRpcAction('actions.getBatchLikeStatus')
-export const editProject = createRpcAction('actions.editProject')
-export const fetchProjectsWithSorting = createRpcAction('actions.fetchProjectsWithSorting')
-export const deleteProject = createRpcAction('actions.deleteProject')
+export const signIn = createRpcAction<
+  Parameters<typeof actions.signIn>,
+  Awaited<ReturnType<typeof actions.signIn>>
+>('actions.signIn')
+export const signUp = createRpcAction<
+  Parameters<typeof actions.signUp>,
+  Awaited<ReturnType<typeof actions.signUp>>
+>('actions.signUp')
+export const signOut = createRpcAction<
+  Parameters<typeof actions.signOut>,
+  Awaited<ReturnType<typeof actions.signOut>>
+>('actions.signOut')
+export const resetPassword = createRpcAction<
+  Parameters<typeof actions.resetPassword>,
+  Awaited<ReturnType<typeof actions.resetPassword>>
+>('actions.resetPassword')
+export const resendConfirmationEmail = createRpcAction<
+  Parameters<typeof actions.resendConfirmationEmail>,
+  Awaited<ReturnType<typeof actions.resendConfirmationEmail>>
+>('actions.resendConfirmationEmail')
+export const getProjectBySlug = createRpcAction<
+  Parameters<typeof actions.getProjectBySlug>,
+  Awaited<ReturnType<typeof actions.getProjectBySlug>>
+>('actions.getProjectBySlug')
+export const getProject = createRpcAction<
+  Parameters<typeof actions.getProject>,
+  Awaited<ReturnType<typeof actions.getProject>>
+>('actions.getProject')
+export const incrementProjectViews = createRpcAction<
+  Parameters<typeof actions.incrementProjectViews>,
+  Awaited<ReturnType<typeof actions.incrementProjectViews>>
+>('actions.incrementProjectViews')
+export const incrementBlogPostViews = createRpcAction<
+  Parameters<typeof actions.incrementBlogPostViews>,
+  Awaited<ReturnType<typeof actions.incrementBlogPostViews>>
+>('actions.incrementBlogPostViews')
+export const toggleLike = createRpcAction<
+  Parameters<typeof actions.toggleLike>,
+  Awaited<ReturnType<typeof actions.toggleLike>>
+>('actions.toggleLike')
+export const getLikeStatus = createRpcAction<
+  Parameters<typeof actions.getLikeStatus>,
+  Awaited<ReturnType<typeof actions.getLikeStatus>>
+>('actions.getLikeStatus')
+export const signInWithGoogle = createRpcAction<
+  Parameters<typeof actions.signInWithGoogle>,
+  Awaited<ReturnType<typeof actions.signInWithGoogle>>
+>('actions.signInWithGoogle')
+export const signInWithGitHub = createRpcAction<
+  Parameters<typeof actions.signInWithGitHub>,
+  Awaited<ReturnType<typeof actions.signInWithGitHub>>
+>('actions.signInWithGitHub')
+export const getBatchLikeStatus = createRpcAction<
+  Parameters<typeof actions.getBatchLikeStatus>,
+  Awaited<ReturnType<typeof actions.getBatchLikeStatus>>
+>('actions.getBatchLikeStatus')
+export const editProject = createRpcAction<
+  Parameters<typeof actions.editProject>,
+  Awaited<ReturnType<typeof actions.editProject>>
+>('actions.editProject')
+export const fetchProjectsWithSorting = createRpcAction<
+  Parameters<typeof actions.fetchProjectsWithSorting>,
+  Awaited<ReturnType<typeof actions.fetchProjectsWithSorting>>
+>('actions.fetchProjectsWithSorting')
+export const deleteProject = createRpcAction<
+  Parameters<typeof actions.deleteProject>,
+  Awaited<ReturnType<typeof actions.deleteProject>>
+>('actions.deleteProject')

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -1,3 +1,5 @@
+'use server'
+
 import { revalidatePath } from '@/lib/cache'
 import { getSiteUrlFromEnv } from '@/lib/env-config'
 import { redirect } from '@/lib/navigation-server'

--- a/lib/actions/admin/admins.ts
+++ b/lib/actions/admin/admins.ts
@@ -1,4 +1,4 @@
-
+'use server'
 
 import { revalidatePath } from '@/lib/cache'
 import { createAdminClient } from '@/lib/supabase/admin'

--- a/lib/actions/comments.ts
+++ b/lib/actions/comments.ts
@@ -1,4 +1,4 @@
-
+'use server'
 
 import { revalidatePath } from '@/lib/cache'
 import type { Comment, CommentEntityType, CommentResult, CreateCommentInput, GetCommentsResult } from '@/types/comments'

--- a/lib/actions/projects.ts
+++ b/lib/actions/projects.ts
@@ -1,4 +1,4 @@
-
+'use server'
 
 import { revalidatePath } from '@/lib/cache'
 import { z } from 'zod'

--- a/lib/actions/user.ts
+++ b/lib/actions/user.ts
@@ -1,4 +1,4 @@
-
+'use server'
 
 import { revalidatePath } from '@/lib/cache'
 import { createClient } from '@/lib/supabase/server'

--- a/lib/env-config.ts
+++ b/lib/env-config.ts
@@ -1,3 +1,5 @@
+import { getSiteUrl } from '@/lib/seo/site-url'
+
 function readEnv(key: string): string {
   if (typeof process !== 'undefined' && process.env[key]) {
     return process.env[key] ?? ''
@@ -24,12 +26,7 @@ function getPublicSupabaseAnonKey(): string {
 }
 
 export function getSiteUrlFromEnv(): string {
-  return (
-    readEnv('VITE_SITE_URL') ||
-    readEnv('NEXT_PUBLIC_SITE_URL') ||
-    (typeof import.meta !== 'undefined' && import.meta.env?.VITE_SITE_URL) ||
-    'http://localhost:5173'
-  )
+  return getSiteUrl()
 }
 
 // Environment configuration with fallbacks for build-time safety

--- a/lib/project-format-description.ts
+++ b/lib/project-format-description.ts
@@ -19,38 +19,46 @@ export function formatProjectDescription(text: string): string {
       const hasBullets = lines.some((line) => /^[\s]*[•\-*]\s/.test(line))
 
       if (hasBullets) {
-        const listItems = lines
-          .map((line) => {
-            const bulletMatch = line.match(/^[\s]*[•\-*]\s*(.*)$/)
-            if (bulletMatch) {
-              return `<li>${bulletMatch[1]}</li>`
-            }
-            return line.trim() ? `<p>${line}</p>` : ''
-          })
-          .filter(Boolean)
-          .join('')
-
         const firstLine = lines[0]
         const isHeader = firstLine && !/^[\s]*[•\-*]\s/.test(firstLine)
 
         if (isHeader) {
           const headerLine = `<p class="font-semibold mt-4 mb-2">${firstLine}</p>`
-          const remainingItems = lines
-            .slice(1)
-            .map((line) => {
-              const bulletMatch = line.match(/^[\s]*[•\-*]\s*(.*)$/)
-              return bulletMatch ? `<li>${bulletMatch[1]}</li>` : ''
-            })
-            .filter(Boolean)
-            .join('')
-          return `${headerLine}<ul class="list-disc list-inside space-y-1 mb-4">${remainingItems}</ul>`
+          return `${headerLine}${formatLinesWithLists(lines.slice(1))}`
         }
 
-        return `<ul class="list-disc list-inside space-y-1 mb-4">${listItems}</ul>`
+        return formatLinesWithLists(lines)
       }
 
       const formattedParagraph = paragraph.replace(/\n/g, '<br>')
       return `<p class="mb-4">${formattedParagraph}</p>`
     })
     .join('')
+}
+
+function formatLinesWithLists(lines: string[]): string {
+  const parts: string[] = []
+  let listItems: string[] = []
+
+  const flushList = () => {
+    if (listItems.length === 0) return
+    parts.push(`<ul class="list-disc list-inside space-y-1 mb-4">${listItems.join('')}</ul>`)
+    listItems = []
+  }
+
+  for (const line of lines) {
+    const bulletMatch = line.match(/^[\s]*[•\-*]\s*(.*)$/)
+    if (bulletMatch) {
+      listItems.push(`<li>${bulletMatch[1]}</li>`)
+      continue
+    }
+
+    flushList()
+    if (line.trim()) {
+      parts.push(`<p class="mb-4">${line}</p>`)
+    }
+  }
+
+  flushList()
+  return parts.join('')
 }

--- a/lib/rpc-client.ts
+++ b/lib/rpc-client.ts
@@ -1,5 +1,3 @@
-import { ServerRedirect } from '@/lib/navigation-server'
-
 export type RpcResult<T> = T | { __redirect: string }
 
 function serializeArg(arg: unknown): unknown {
@@ -38,14 +36,6 @@ export async function invokeRpc<T>(procedure: string, args: unknown[]): Promise<
     }),
   })
 
-  if (response.status === 302 || response.status === 301) {
-    const location = response.headers.get('Location')
-    if (location) {
-      window.location.href = location
-      return undefined as T
-    }
-  }
-
   const payload = (await response.json()) as { ok: boolean; data?: T; error?: string; redirect?: string }
 
   if (payload.redirect) {
@@ -63,17 +53,7 @@ export async function invokeRpc<T>(procedure: string, args: unknown[]): Promise<
 export function createRpcAction<TArgs extends unknown[], TResult>(
   procedure: string,
 ): (...args: TArgs) => Promise<TResult> {
-  return async (...args: TArgs) => {
-    try {
-      return await invokeRpc<TResult>(procedure, args)
-    } catch (error) {
-      if (error instanceof ServerRedirect) {
-        window.location.href = error.url
-        return undefined as TResult
-      }
-      throw error
-    }
-  }
+  return (...args: TArgs) => invokeRpc<TResult>(procedure, args)
 }
 
 export function formDataFromRpc(arg: unknown): FormData {

--- a/lib/seo/messages.ts
+++ b/lib/seo/messages.ts
@@ -15,5 +15,5 @@ export function getMetadataMessages(locale: SeoLocale): MetadataMessages {
 }
 
 export function formatTitle(template: string, pageTitle: string): string {
-  return template.replace('%s', pageTitle)
+  return template.replace('%s', () => pageTitle)
 }

--- a/lib/seo/render-meta.ts
+++ b/lib/seo/render-meta.ts
@@ -2,6 +2,10 @@ import type { PageMeta } from '@/lib/seo/types'
 import { absoluteUrl } from '@/lib/seo/site-url'
 import { SITE_NAME, TWITTER_SITE } from '@/lib/seo/constants'
 
+function serializeJsonLd(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c')
+}
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -65,7 +69,7 @@ export function renderPageMetaTags(meta: PageMeta): string {
   if (meta.jsonLd) {
     const blocks = Array.isArray(meta.jsonLd) ? meta.jsonLd : [meta.jsonLd]
     for (const block of blocks) {
-      lines.push(`<script type="application/ld+json">${JSON.stringify(block)}</script>`)
+      lines.push(`<script type="application/ld+json">${serializeJsonLd(block)}</script>`)
     }
   }
 

--- a/src/client/compat/next-intl-routing.ts
+++ b/src/client/compat/next-intl-routing.ts
@@ -1,10 +1,4 @@
-export const routing = {
-  locales: ['id', 'en'] as const,
-  defaultLocale: 'id' as const,
-  localePrefix: 'as-needed' as const,
-}
-
-export type Locale = (typeof routing.locales)[number]
+export { routing, type Locale } from '@/i18n/routing.vite'
 
 export function defineRouting<T>(config: T): T {
   return config

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -20,6 +20,7 @@ app.use(
 
 app.use('*', localeMiddleware)
 app.use('/api/*', supabaseMiddleware)
+app.use('/auth/callback', supabaseMiddleware)
 
 app.route('/', seoRoutes)
 app.route('/api', rpcRoutes)

--- a/src/server/routes/seo.ts
+++ b/src/server/routes/seo.ts
@@ -27,11 +27,14 @@ seoRoutes.get('/api/seo/meta', async (c) => {
 export async function documentHandler(c: import('hono').Context): Promise<Response | null> {
   const pathname = new URL(c.req.url).pathname
 
-  if (!shouldHandleAsDocument(pathname)) {
+  if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
     return null
   }
 
-  if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+  const staticResponse = await tryServeProductionStatic(c)
+  if (staticResponse) return staticResponse
+
+  if (!shouldHandleAsDocument(pathname)) {
     return null
   }
 
@@ -39,9 +42,6 @@ export async function documentHandler(c: import('hono').Context): Promise<Respon
   if (accept && !accept.includes('text/html') && !accept.includes('*/*') && accept.includes('application/json')) {
     return null
   }
-
-  const staticResponse = await tryServeProductionStatic(c)
-  if (staticResponse) return staticResponse
 
   const locale = resolveLocaleFromPath(pathname, getCookieLocale(c))
   const meta = await runWithHonoRequestContext(c, () => resolvePageMeta(pathname, locale))

--- a/tests/unit/lib/project-format-description.spec.ts
+++ b/tests/unit/lib/project-format-description.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { formatProjectDescription } from '@/lib/project-format-description'
+
+describe('formatProjectDescription', () => {
+  it('keeps non-bullet lines between bullets outside the list', () => {
+    const html = formatProjectDescription('Features\n- Item A\nAlso supports X\n- Item B')
+    expect(html).toContain('Also supports X')
+    expect(html).not.toMatch(/<ul[^>]*>[\s\S]*<p>/)
+    expect(html).toMatch(/<ul[^>]*>[\s\S]*<li>Item A<\/li>[\s\S]*<\/ul>/)
+    expect(html).toMatch(/<ul[^>]*>[\s\S]*<li>Item B<\/li>[\s\S]*<\/ul>/)
+  })
+
+  it('does not place paragraphs inside unordered lists', () => {
+    const html = formatProjectDescription('- One\nPlain line\n- Two')
+    expect(html).not.toMatch(/<ul[^>]*>[\s\S]*<p>Plain line<\/p>[\s\S]*<\/ul>/)
+    expect(html).toContain('<p class="mb-4">Plain line</p>')
+  })
+})

--- a/tests/unit/lib/render-meta.spec.ts
+++ b/tests/unit/lib/render-meta.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { renderPageMetaTags } from '@/lib/seo/render-meta'
+
+describe('renderPageMetaTags', () => {
+  it('escapes script-breakout sequences in JSON-LD', () => {
+    const tags = renderPageMetaTags({
+      title: 'Test',
+      description: 'Test',
+      canonical: 'https://example.com',
+      jsonLd: {
+        '@context': 'https://schema.org',
+        name: '</script><script>alert(1)</script>',
+      },
+    })
+
+    expect(tags).toContain('\\u003c/script')
+    expect(tags).not.toMatch(/<\/script><script>/)
+  })
+})

--- a/tests/unit/lib/seo-messages.spec.ts
+++ b/tests/unit/lib/seo-messages.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { formatTitle } from '@/lib/seo/messages'
+
+describe('formatTitle', () => {
+  it('preserves dollar-sign replacement patterns in page titles', () => {
+    expect(formatTitle('%s | VibeDev ID', 'My $& Project')).toBe('My $& Project | VibeDev ID')
+    expect(formatTitle('%s | VibeDev ID', 'Price $1 deal')).toBe('Price $1 deal | VibeDev ID')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Validates and fixes reported P0–P2 issues across server routing, SEO, actions, i18n, and description formatting.

## Production-critical fixes

- **`/auth/callback`**: Mount `supabaseMiddleware` so OAuth code exchange runs with request context and can set session cookies.
- **Static assets**: Serve production static files before `shouldHandleAsDocument` so `/assets/*` is not dropped.
- **Site URL**: `getSiteUrlFromEnv()` delegates to `getSiteUrl()` — no silent `localhost` fallback in production.

## Security / correctness

- **JSON-LD**: Escape `<` in serialized JSON-LD to prevent `</script>` breakout.
- **`formatTitle`**: Use replacement callback so `$&`, `$1`, etc. in user titles are not mangled.
- **RPC client**: Remove dead HTTP 301/302 handling (`fetch` follows redirects; server returns JSON `redirect`).

## UX / maintainability

- **Project descriptions**: Valid list markup (no `<p>` inside `<ul>`); preserve non-bullet lines after headers.
- **i18n routing**: Single source in `i18n/routing.vite.ts`; compat re-exports; removed unused `localePrefix`.
- **Server actions**: Restored `'use server'` on flagged action modules for legacy Next.js boundaries.
- **RPC typings**: `lib/actions.client.ts` stubs typed via `import type` from `./actions`.

## Tests

Added unit tests for JSON-LD escaping, `formatTitle`, and description formatting (`tests/unit/lib/*`).

## Notes

- `'use server'` on action modules is required for legacy `app/` client imports; production Vite client builds still use `*.client.ts` RPC stubs via aliases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb2565f6-670b-4187-a351-ecc43420ff15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb2565f6-670b-4187-a351-ecc43420ff15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

