### PR TITLE
fix(i18n): add trendingOptions to projectList namespace

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -191,7 +191,12 @@
     "submitButton": "Submit Project",
     "noProjects": "No projects found with the selected filter",
     "beFirst": "Be the First to Submit a Project",
-    "showingProjects": "Showing {count} projects from the Indonesian developer community"
+    "showingProjects": "Showing {count} projects from the Indonesian developer community",
+    "trendingOptions": {
+      "trending": "Trending",
+      "top": "Top",
+      "newest": "Newest"
+    }
   },
   "projectSubmit": {
     "title": "Submit Your Project",

--- a/messages/id.json
+++ b/messages/id.json
@@ -191,7 +191,12 @@
     "submitButton": "Submit Project",
     "noProjects": "Belum ada project dengan filter yang dipilih",
     "beFirst": "Jadi yang Pertama Submit Project",
-    "showingProjects": "Menampilkan {count} project dari komunitas developer Indonesia"
+    "showingProjects": "Menampilkan {count} project dari komunitas developer Indonesia",
+    "trendingOptions": {
+      "trending": "Trending",
+      "top": "Top",
+      "newest": "Terbaru"
+    }
   },
   "projectSubmit": {
     "title": "Submit Project Anda",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the project list sort dropdown showing raw translation keys like `projectList.trending()` on production.

## Root cause

`app/project/list/project-list-client.tsx` uses `useTranslations('projectList')` and reads `t('trendingOptions.trending')`, but `trendingOptions` only existed under the `projectShowcase` namespace in `messages/*.json`.

## Changes

- Added `trendingOptions` (`trending`, `top`, `newest`) to `projectList` in `messages/id.json` and `messages/en.json`

## Verification

After deploy, open `/project/list` and confirm the sort dropdown shows **Trending / Top / Terbaru** instead of raw key text.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea9c0-3167-7702-b481-5fc32c50bf7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea9c0-3167-7702-b481-5fc32c50bf7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

